### PR TITLE
move library to src folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,11 @@ The directory structure of your new project looks like this:
 
 ```
 .
-├── Library submodule         <- SeismicPro, SeismiQB or PetroFlow as a git submodule
 ├── datasets                  <- Keep your datasets here
 ├── docker_containers
 ├── .dockerignore
+├── .dvc
+├── .dvcignore
 ├── extra                     <- extra helper utilities that are not project-specific, ex. cookiecutter template updater
 │   ├── .cookiecutter.json
 │   ├── src
@@ -66,12 +67,16 @@ The directory structure of your new project looks like this:
 │   └── workflows
 │       └── status.yml
 ├── .gitignore
+├── .gitmodules
 ├── notebooks                 <- Development notebooks
 ├── overview                  <- Notebooks with overview of main results
 ├── pylintrc
 ├── readme.md                 <- The top-level README for developers using this project.
 ├── requirements.txt
 ├── src                       <- Project-specific models and utilities
+│   ├── Library submodule     <- SeismicPro, SeismiQB, PetroFlow, or batchflow as a git submodule
+│   ├── __init__.py
+│   └── readme.md
 └── tests
 
 ```

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -33,11 +33,11 @@ if library is not "no":
     print("adding submodule", library, "...")
 
     path = libpaths[library]
-    subprocess.run(['git', 'submodule', 'add', path])
+    subprocess.run(['git', 'submodule', 'add', path], cwd='src')
     subprocess.run(['git', 'submodule', 'update', '--init', '--recursive'])
 
     print("copying requirements...")
-    shutil.copyfile(os.path.join(library, 'requirements.txt'), 'requirements.txt')
+    shutil.copyfile(os.path.join('src', library, 'requirements.txt'), 'requirements.txt')
 
 
 print("adding files to git ...")

--- a/{{cookiecutter.repo_name}}/.github/workflows/status.yml
+++ b/{{cookiecutter.repo_name}}/.github/workflows/status.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     container:
-      image: analysiscenter1/ds-py3:cpu
+      image: analysiscenter1/ds-py3
 
     steps:
     - uses: actions/checkout@v1

--- a/{{cookiecutter.repo_name}}/readme.md
+++ b/{{cookiecutter.repo_name}}/readme.md
@@ -6,11 +6,12 @@ Add your project description here
 ### Project structure
 
 ```
-{% if cookiecutter.include_library != 'no' %}
-├── {{ cookiecutter.include_library }}         <- {{ cookiecutter.include_library }} as a git submodule {% endif %}
+
 ├── datasets                  <- Keep your datasets here
 ├── docker_containers
 ├── .dockerignore
+├── .dvc
+├── .dvcignore
 ├── extra                     <- extra helper utilities that are not project-specific, ex. cookiecutter template updater
 │   ├── .cookiecutter.json
 │   ├── src
@@ -21,12 +22,17 @@ Add your project description here
 │   └── workflows
 │       └── status.yml
 ├── .gitignore
+├── .gitmodules
 ├── notebooks                 <- Development notebooks
 ├── overview                  <- Notebooks with overview of main results
 ├── pylintrc
 ├── readme.md                 <- The top-level README for developers using this project.
 ├── requirements.txt
 ├── src                       <- Project-specific models and utilities
+{% if cookiecutter.include_library != 'no' %}
+│   ├── {{ cookiecutter.include_library }}         <- {{ cookiecutter.include_library }} as a git submodule {% endif %}
+│   ├── __init__.py
+│   └── readme.md
 └── tests
 
 ```


### PR DESCRIPTION
Labraries submodules are moved into `src` folder to simplify imports: no `sys.path` modifications needed in project modules (they are still needed in notebooks)

+ fixed container in status.yml

what about removing Petroflow from submodules list?